### PR TITLE
Add gallery popout mode

### DIFF
--- a/project1.html
+++ b/project1.html
@@ -81,6 +81,38 @@
     .prev { left: 10px; }
     .next { right: 10px; }
 
+    .fullscreen-btn {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background-color: rgba(0, 0, 0, 0.4);
+      color: white;
+      border: none;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      z-index: 1;
+    }
+
+    .slider-wrapper.popout {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 90vw;
+      height: 80vh;
+      max-width: none;
+      background: rgba(0, 0, 0, 0.9);
+      z-index: 1000;
+    }
+
+    .slider-wrapper.popout img {
+      width: 100%;
+      height: auto;
+      max-height: 100%;
+      object-fit: contain;
+    }
+
     footer {
       padding: 40px 20px;
       text-align: center;
@@ -122,6 +154,7 @@
         </div>
         <button class="prev">&#10094;</button>
         <button class="next">&#10095;</button>
+        <button class="fullscreen-btn">Fullscreen</button>
       </div>
         <hr style="margin: 60px auto; max-width: 800px; border: 1px solid #ccc;">
     <div style="text-align: center; font-weight: 600; font-size: 1rem; line-height: 2;">
@@ -144,6 +177,8 @@
   <script>
     const slider = document.querySelector('.slider');
     const slides = slider.querySelectorAll('img');
+    const fullscreenBtn = document.querySelector('.fullscreen-btn');
+    const sliderWrapper = document.querySelector('.slider-wrapper');
     let index = 0;
 
     // Function to update the slider instantly without a transition
@@ -163,6 +198,10 @@
       index = (index - 1 + slides.length) % slides.length;
       updateSliderInstantly();
     };
+
+    fullscreenBtn.addEventListener('click', () => {
+      sliderWrapper.classList.toggle('popout');
+    });
 
     // Function to go to the next image on click
     slider.addEventListener('click', () => {

--- a/project10.html
+++ b/project10.html
@@ -105,6 +105,37 @@
 
     .prev { left: 10px; }
     .next { right: 10px; }
+    .fullscreen-btn {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background-color: rgba(0, 0, 0, 0.4);
+      color: white;
+      border: none;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      z-index: 1;
+    }
+
+    .slider-wrapper.popout {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 90vw;
+      height: 80vh;
+      max-width: none;
+      background: rgba(0, 0, 0, 0.9);
+      z-index: 1000;
+    }
+
+    .slider-wrapper.popout img {
+      width: 100%;
+      height: auto;
+      max-height: 100%;
+      object-fit: contain;
+    }
 
     .credits {
       text-align: centre;
@@ -165,6 +196,7 @@
         </div>
         <button class="prev">&#10094;</button>
         <button class="next">&#10095;</button>
+        <button class="fullscreen-btn">Fullscreen</button>
       </div>
       <div class="credits">
         <p><strong>Writer / Director:
@@ -292,7 +324,13 @@ Jaap Meindersma
   <script>
     const slider = document.querySelector('.slider');
     const slides = slider.querySelectorAll('img');
+    const fullscreenBtn = document.querySelector('.fullscreen-btn');
+    const sliderWrapper = document.querySelector('.slider-wrapper');
     let index = 0;
+
+    fullscreenBtn.addEventListener('click', () => {
+      sliderWrapper.classList.toggle('popout');
+    });
 
     function updateSliderInstantly() {
       slider.style.transition = 'none';

--- a/project11.html
+++ b/project11.html
@@ -105,6 +105,37 @@
 
     .prev { left: 10px; }
     .next { right: 10px; }
+    .fullscreen-btn {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background-color: rgba(0, 0, 0, 0.4);
+      color: white;
+      border: none;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      z-index: 1;
+    }
+
+    .slider-wrapper.popout {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 90vw;
+      height: 80vh;
+      max-width: none;
+      background: rgba(0, 0, 0, 0.9);
+      z-index: 1000;
+    }
+
+    .slider-wrapper.popout img {
+      width: 100%;
+      height: auto;
+      max-height: 100%;
+      object-fit: contain;
+    }
 
     .credits {
       text-align: centre;
@@ -165,6 +196,7 @@
         </div>
         <button class="prev">&#10094;</button>
         <button class="next">&#10095;</button>
+        <button class="fullscreen-btn">Fullscreen</button>
       </div>
       <div class="credits">
         <p><strong>Written and Directed by
@@ -207,7 +239,13 @@ Loeki van der Horst, Nurana Akbarova, Isabel Steegman
   <script>
     const slider = document.querySelector('.slider');
     const slides = slider.querySelectorAll('img');
+    const fullscreenBtn = document.querySelector('.fullscreen-btn');
+    const sliderWrapper = document.querySelector('.slider-wrapper');
     let index = 0;
+
+    fullscreenBtn.addEventListener('click', () => {
+      sliderWrapper.classList.toggle('popout');
+    });
 
     function updateSliderInstantly() {
       slider.style.transition = 'none';

--- a/project2.html
+++ b/project2.html
@@ -89,6 +89,37 @@
 
     .prev { left: 10px; }
     .next { right: 10px; }
+    .fullscreen-btn {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background-color: rgba(0, 0, 0, 0.4);
+      color: white;
+      border: none;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      z-index: 1;
+    }
+
+    .slider-wrapper.popout {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 90vw;
+      height: 80vh;
+      max-width: none;
+      background: rgba(0, 0, 0, 0.9);
+      z-index: 1000;
+    }
+
+    .slider-wrapper.popout img {
+      width: 100%;
+      height: auto;
+      max-height: 100%;
+      object-fit: contain;
+    }
 
     footer {
       padding: 40px 20px;
@@ -133,6 +164,7 @@
         </div>
         <button class="prev">&#10094;</button>
         <button class="next">&#10095;</button>
+        <button class="fullscreen-btn">Fullscreen</button>
       </div>
       <hr style="margin: 60px auto; max-width: 800px; border: 1px solid #ccc;">
       <div style="text-align: center; font-weight: 600; font-size: 1rem; line-height: 2;">
@@ -158,7 +190,13 @@
   <script>
     const slider = document.querySelector('.slider');
     const slides = slider.querySelectorAll('img');
+    const fullscreenBtn = document.querySelector('.fullscreen-btn');
+    const sliderWrapper = document.querySelector('.slider-wrapper');
     let index = 0;
+
+    fullscreenBtn.addEventListener('click', () => {
+      sliderWrapper.classList.toggle('popout');
+    });
 
     // Function to update the slider instantly without a transition
     function updateSliderInstantly() {

--- a/project3.html
+++ b/project3.html
@@ -89,6 +89,37 @@
 
     .prev { left: 10px; }
     .next { right: 10px; }
+    .fullscreen-btn {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background-color: rgba(0, 0, 0, 0.4);
+      color: white;
+      border: none;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      z-index: 1;
+    }
+
+    .slider-wrapper.popout {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 90vw;
+      height: 80vh;
+      max-width: none;
+      background: rgba(0, 0, 0, 0.9);
+      z-index: 1000;
+    }
+
+    .slider-wrapper.popout img {
+      width: 100%;
+      height: auto;
+      max-height: 100%;
+      object-fit: contain;
+    }
 
     footer {
       padding: 40px 20px;
@@ -132,6 +163,7 @@
         </div>
         <button class="prev">&#10094;</button>
         <button class="next">&#10095;</button>
+        <button class="fullscreen-btn">Fullscreen</button>
       </div>
       <hr style="margin: 60px auto; max-width: 800px; border: 1px solid #ccc;">
       <div style="text-align: center; font-weight: 600; font-size: 1rem; line-height: 2;">
@@ -154,7 +186,13 @@
   <script>
     const slider = document.querySelector('.slider');
     const slides = slider.querySelectorAll('img');
+    const fullscreenBtn = document.querySelector('.fullscreen-btn');
+    const sliderWrapper = document.querySelector('.slider-wrapper');
     let index = 0;
+
+    fullscreenBtn.addEventListener('click', () => {
+      sliderWrapper.classList.toggle('popout');
+    });
 
     // Function to update the slider instantly without a transition
     function updateSliderInstantly() {

--- a/project4.html
+++ b/project4.html
@@ -104,6 +104,37 @@
 
     .prev { left: 10px; }
     .next { right: 10px; }
+    .fullscreen-btn {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background-color: rgba(0, 0, 0, 0.4);
+      color: white;
+      border: none;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      z-index: 1;
+    }
+
+    .slider-wrapper.popout {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 90vw;
+      height: 80vh;
+      max-width: none;
+      background: rgba(0, 0, 0, 0.9);
+      z-index: 1000;
+    }
+
+    .slider-wrapper.popout img {
+      width: 100%;
+      height: auto;
+      max-height: 100%;
+      object-fit: contain;
+    }
 
     footer {
       padding: 40px 20px;
@@ -147,6 +178,7 @@
         </div>
         <button class="prev">&#10094;</button>
         <button class="next">&#10095;</button>
+        <button class="fullscreen-btn">Fullscreen</button>
       </div>
       <div class="credits">
         <p><strong>Director:</strong> Evy Hachmang</p>
@@ -178,7 +210,13 @@
   <script>
     const slider = document.querySelector('.slider');
     const slides = slider.querySelectorAll('img');
+    const fullscreenBtn = document.querySelector('.fullscreen-btn');
+    const sliderWrapper = document.querySelector('.slider-wrapper');
     let index = 0;
+
+    fullscreenBtn.addEventListener('click', () => {
+      sliderWrapper.classList.toggle('popout');
+    });
 
     // Function to update the slider instantly without a transition
     function updateSliderInstantly() {

--- a/project5.html
+++ b/project5.html
@@ -104,6 +104,37 @@
 
     .prev { left: 10px; }
     .next { right: 10px; }
+    .fullscreen-btn {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background-color: rgba(0, 0, 0, 0.4);
+      color: white;
+      border: none;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      z-index: 1;
+    }
+
+    .slider-wrapper.popout {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 90vw;
+      height: 80vh;
+      max-width: none;
+      background: rgba(0, 0, 0, 0.9);
+      z-index: 1000;
+    }
+
+    .slider-wrapper.popout img {
+      width: 100%;
+      height: auto;
+      max-height: 100%;
+      object-fit: contain;
+    }
 
     footer {
       padding: 40px 20px;
@@ -147,6 +178,7 @@
         </div>
         <button class="prev">&#10094;</button>
         <button class="next">&#10095;</button>
+        <button class="fullscreen-btn">Fullscreen</button>
       </div>
       <div class="credits">
         <p><strong>Director:</strong> Sam Bogstedt</p>
@@ -168,7 +200,13 @@
   <script>
     const slider = document.querySelector('.slider');
     const slides = slider.querySelectorAll('img');
+    const fullscreenBtn = document.querySelector('.fullscreen-btn');
+    const sliderWrapper = document.querySelector('.slider-wrapper');
     let index = 0;
+
+    fullscreenBtn.addEventListener('click', () => {
+      sliderWrapper.classList.toggle('popout');
+    });
 
     function updateSliderInstantly() {
       slider.style.transition = 'none';

--- a/project6.html
+++ b/project6.html
@@ -105,6 +105,37 @@
 
     .prev { left: 10px; }
     .next { right: 10px; }
+    .fullscreen-btn {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background-color: rgba(0, 0, 0, 0.4);
+      color: white;
+      border: none;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      z-index: 1;
+    }
+
+    .slider-wrapper.popout {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 90vw;
+      height: 80vh;
+      max-width: none;
+      background: rgba(0, 0, 0, 0.9);
+      z-index: 1000;
+    }
+
+    .slider-wrapper.popout img {
+      width: 100%;
+      height: auto;
+      max-height: 100%;
+      object-fit: contain;
+    }
 
     .credits {
       text-align: centre;
@@ -163,6 +194,7 @@
         </div>
         <button class="prev">&#10094;</button>
         <button class="next">&#10095;</button>
+        <button class="fullscreen-btn">Fullscreen</button>
       </div>
       <div class="credits">
         <p><strong>Written & Directed by:</strong> Tijmen Snoep</p>
@@ -201,7 +233,13 @@
   <script>
     const slider = document.querySelector('.slider');
     const slides = slider.querySelectorAll('img');
+    const fullscreenBtn = document.querySelector('.fullscreen-btn');
+    const sliderWrapper = document.querySelector('.slider-wrapper');
     let index = 0;
+
+    fullscreenBtn.addEventListener('click', () => {
+      sliderWrapper.classList.toggle('popout');
+    });
 
     function updateSliderInstantly() {
       slider.style.transition = 'none';

--- a/project7.html
+++ b/project7.html
@@ -105,6 +105,37 @@
 
     .prev { left: 10px; }
     .next { right: 10px; }
+    .fullscreen-btn {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background-color: rgba(0, 0, 0, 0.4);
+      color: white;
+      border: none;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      z-index: 1;
+    }
+
+    .slider-wrapper.popout {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 90vw;
+      height: 80vh;
+      max-width: none;
+      background: rgba(0, 0, 0, 0.9);
+      z-index: 1000;
+    }
+
+    .slider-wrapper.popout img {
+      width: 100%;
+      height: auto;
+      max-height: 100%;
+      object-fit: contain;
+    }
 
     .credits {
       text-align: center;
@@ -163,6 +194,7 @@
         </div>
         <button class="prev">&#10094;</button>
         <button class="next">&#10095;</button>
+        <button class="fullscreen-btn">Fullscreen</button>
       </div>
       <div class="credits">
         <p><strong>Made by:</strong> Sam Bogstedt</p>
@@ -184,7 +216,13 @@
   <script>
     const slider = document.querySelector('.slider');
     const slides = slider.querySelectorAll('img');
+    const fullscreenBtn = document.querySelector('.fullscreen-btn');
+    const sliderWrapper = document.querySelector('.slider-wrapper');
     let index = 0;
+
+    fullscreenBtn.addEventListener('click', () => {
+      sliderWrapper.classList.toggle('popout');
+    });
 
     function updateSliderInstantly() {
       slider.style.transition = 'none';

--- a/project8.html
+++ b/project8.html
@@ -105,6 +105,37 @@
 
     .prev { left: 10px; }
     .next { right: 10px; }
+    .fullscreen-btn {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background-color: rgba(0, 0, 0, 0.4);
+      color: white;
+      border: none;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      z-index: 1;
+    }
+
+    .slider-wrapper.popout {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 90vw;
+      height: 80vh;
+      max-width: none;
+      background: rgba(0, 0, 0, 0.9);
+      z-index: 1000;
+    }
+
+    .slider-wrapper.popout img {
+      width: 100%;
+      height: auto;
+      max-height: 100%;
+      object-fit: contain;
+    }
 
     .credits {
       text-align: centre;
@@ -157,6 +188,7 @@
         </div>
         <button class="prev">&#10094;</button>
         <button class="next">&#10095;</button>
+        <button class="fullscreen-btn">Fullscreen</button>
       </div>
       <div class="credits">
         <p><strong>Made by:</strong> Sam Bogstedt</p>
@@ -177,7 +209,13 @@
   <script>
     const slider = document.querySelector('.slider');
     const slides = slider.querySelectorAll('img');
+    const fullscreenBtn = document.querySelector('.fullscreen-btn');
+    const sliderWrapper = document.querySelector('.slider-wrapper');
     let index = 0;
+
+    fullscreenBtn.addEventListener('click', () => {
+      sliderWrapper.classList.toggle('popout');
+    });
 
     function updateSliderInstantly() {
       slider.style.transition = 'none';

--- a/project9.html
+++ b/project9.html
@@ -105,6 +105,37 @@
 
     .prev { left: 10px; }
     .next { right: 10px; }
+    .fullscreen-btn {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background-color: rgba(0, 0, 0, 0.4);
+      color: white;
+      border: none;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      z-index: 1;
+    }
+
+    .slider-wrapper.popout {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 90vw;
+      height: 80vh;
+      max-width: none;
+      background: rgba(0, 0, 0, 0.9);
+      z-index: 1000;
+    }
+
+    .slider-wrapper.popout img {
+      width: 100%;
+      height: auto;
+      max-height: 100%;
+      object-fit: contain;
+    }
 
     .credits {
       text-align: centre;
@@ -159,6 +190,7 @@
         </div>
         <button class="prev">&#10094;</button>
         <button class="next">&#10095;</button>
+        <button class="fullscreen-btn">Fullscreen</button>
       </div>
       <div class="credits">
         <p><strong>Song By: Hannah Lahaije
@@ -190,7 +222,13 @@
   <script>
     const slider = document.querySelector('.slider');
     const slides = slider.querySelectorAll('img');
+    const fullscreenBtn = document.querySelector('.fullscreen-btn');
+    const sliderWrapper = document.querySelector('.slider-wrapper');
     let index = 0;
+
+    fullscreenBtn.addEventListener('click', () => {
+      sliderWrapper.classList.toggle('popout');
+    });
 
     function updateSliderInstantly() {
       slider.style.transition = 'none';


### PR DESCRIPTION
## Summary
- tweak slider style to use a popout class rather than browser fullscreen
- toggle `.popout` via JavaScript on each project page
- ensure each slide stays isolated so images don't overlap

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868ff79fd54833293b92959c3dc100f